### PR TITLE
UserBundle uses 'email' instead of 'e-mail'

### DIFF
--- a/Resources/doc/configure_user_manager.md
+++ b/Resources/doc/configure_user_manager.md
@@ -239,7 +239,7 @@ class OpenIdUserManager extends UserManager
         }
         // in this example, we fetch User entities by e-mail
         $user = $this->entityManager->getRepository('AcmeDemoBundle:User')->findOneBy(array(
-            'e-mail' => $attributes['contact/email']
+            'email' => $attributes['contact/email']
         ));
 
         if (null === $user) {


### PR DESCRIPTION
When using the Acme\UserBundle\Entity\User class from the cookbook (http://symfony.com/doc/current/cookbook/security/entity_provider.html#introduction), the field "email" is used, and not e-mail.
