### PR TITLE
AuthenticationServiceException constructor have 3 params

### DIFF
--- a/Security/Core/Authentication/Provider/OpenIdAuthenticationProvider.php
+++ b/Security/Core/Authentication/Provider/OpenIdAuthenticationProvider.php
@@ -90,7 +90,7 @@ class OpenIdAuthenticationProvider implements AuthenticationProviderInterface
         } catch (AuthenticationException $e) {
             throw $e;
         } catch (\Exception $e) {
-            throw new AuthenticationServiceException($e->getMessage(), null, (int) $e->getCode(), $e);
+            throw new AuthenticationServiceException($e->getMessage(), (int) $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
Fatal error if throw not AuthenticationException in file
Security/Core/Authentication/Provider/OpenIdAuthenticationProvider.php:93
