### PR TITLE
Fixes for Symfony 2.7 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 
 before_script: composer install --dev
 

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Fp\OpenIdBundle\Controller;
 
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\DependencyInjection\ContainerAware;
 
 class SecurityController extends ContainerAware
@@ -11,14 +11,14 @@ class SecurityController extends ContainerAware
         $request = $this->container->get('request');
         /* @var $request \Symfony\Component\HttpFoundation\Request */
         $session = $request->getSession();
-        /* @var $session \Symfony\Component\HttpFoundation\Session */
+        /* @var $session \Symfony\Component\HttpFoundation\Session\SessionInterface */
 
         // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
-        } elseif (null !== $session && $session->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
+        } elseif (null !== $session && $session->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $session->get(Security::AUTHENTICATION_ERROR);
+            $session->remove(Security::AUTHENTICATION_ERROR);
         } else {
             $error = '';
         }

--- a/DependencyInjection/FpOpenIdExtension.php
+++ b/DependencyInjection/FpOpenIdExtension.php
@@ -6,7 +6,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Reference;
 
 class FpOpenIdExtension extends Extension
 {

--- a/Model/UserManager.php
+++ b/Model/UserManager.php
@@ -7,9 +7,6 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 
 use Fp\OpenIdBundle\Security\Core\User\UserManagerInterface;
-use Fp\OpenIdBundle\Model\IdentityManagerInterface;
-use Fp\OpenIdBundle\Model\IdentityInterface;
-use Fp\OpenIdBundle\Model\UserIdentityInterface;
 
 class UserManager implements UserManagerInterface
 {

--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,8 @@ The bulk of the documentation is stored in the `Resources/doc/index.md` file in 
 
 [Read the Documentation for master](Resources/doc/index.md)
 
+[Read the Documentation for 2.7-dev (for Symfony 2.7.x)](https://github.com/formapro/FpOpenIdBundle/blob/2.7.0/Resources/doc/index.md)
+
 [Read the Documentation for 1.3.0 (for Symfony 2.1.x)](https://github.com/formapro/FpOpenIdBundle/blob/1.3/Resources/doc/index.md)
 
 [Read the Documentation for 1.2.0 (for Symfony 2.0.x)](https://github.com/formapro/FpOpenIdBundle/blob/1.2/Resources/doc/index.md)

--- a/RelyingParty/RecoveredFailureRelyingParty.php
+++ b/RelyingParty/RecoveredFailureRelyingParty.php
@@ -2,7 +2,7 @@
 namespace Fp\OpenIdBundle\RelyingParty;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
 
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
 
@@ -18,7 +18,7 @@ class RecoveredFailureRelyingParty implements RelyingPartyInterface
         if (false == $request->get(self::RECOVERED_QUERY_PARAMETER)) {
             return false;
         }
-        if (false == $error = $request->getSession()->get(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+        if (false == $error = $request->getSession()->get(Security::AUTHENTICATION_ERROR)) {
             return false;
         }
         if (false == $error->getToken() instanceof OpenIdToken) {
@@ -37,9 +37,9 @@ class RecoveredFailureRelyingParty implements RelyingPartyInterface
             throw new \InvalidArgumentException('The relying party does not support the request');
         }
 
-        $error = $request->getSession()->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        $error = $request->getSession()->get(Security::AUTHENTICATION_ERROR);
 
-        $request->getSession()->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
+        $request->getSession()->remove(Security::AUTHENTICATION_ERROR);
 
         return new IdentityProviderResponse(
             $error->getToken()->getIdentity(),

--- a/RelyingParty/RelyingPartyCollection.php
+++ b/RelyingParty/RelyingPartyCollection.php
@@ -2,9 +2,6 @@
 namespace Fp\OpenIdBundle\RelyingParty;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\SecurityContextInterface;
-
-use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
 
 class RelyingPartyCollection implements RelyingPartyInterface
 {

--- a/Resources/config/routing/security.xml
+++ b/Resources/config/routing/security.xml
@@ -4,15 +4,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fp_openid_security_login" pattern="/login_openid">
+    <route id="fp_openid_security_login" path="/login_openid">
         <default key="_controller">FpOpenIdBundle:Security:login</default>
     </route>
 
-    <route id="fp_openid_security_check" pattern="/login_check_openid">
+    <route id="fp_openid_security_check" path="/login_check_openid">
         <default key="_controller">FpOpenIdBundle:Security:check</default>
     </route>
 
-    <route id="fp_openid_security_logout" pattern="/logout">
+    <route id="fp_openid_security_logout" path="/logout">
         <default key="_controller">FpOpenIdBundle:Security:logout</default>
     </route>
 

--- a/Security/Core/Authentication/Provider/OpenIdAuthenticationProvider.php
+++ b/Security/Core/Authentication/Provider/OpenIdAuthenticationProvider.php
@@ -12,7 +12,6 @@ use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProvid
 
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
 use Fp\OpenIdBundle\Security\Core\User\UserManagerInterface;
-use Fp\OpenIdBundle\Security\Core\Exception\UsernameByIdentityNotFoundException;
 
 class OpenIdAuthenticationProvider implements AuthenticationProviderInterface
 {

--- a/Security/Core/Authentication/Token/OpenIdToken.php
+++ b/Security/Core/Authentication/Token/OpenIdToken.php
@@ -2,7 +2,6 @@
 namespace Fp\OpenIdBundle\Security\Core\Authentication\Token;
 
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
-use Symfony\Component\HttpFoundation\Response;
 
 class OpenIdToken extends AbstractToken
 {

--- a/Security/Http/Firewall/AbstractOpenIdAuthenticationListener.php
+++ b/Security/Http/Firewall/AbstractOpenIdAuthenticationListener.php
@@ -1,17 +1,16 @@
 <?php
 namespace Fp\OpenIdBundle\Security\Http\Firewall;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\ParameterBag;
 
 use Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface;
 
@@ -22,7 +21,7 @@ abstract class AbstractOpenIdAuthenticationListener extends AbstractAuthenticati
      */
     private $relyingParty;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null) 
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         $options = array_merge(array(
             'required_attributes' => array(),
@@ -30,7 +29,7 @@ abstract class AbstractOpenIdAuthenticationListener extends AbstractAuthenticati
             'target_path_parameter' => '_target_path',
         ), $options);
         
-        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, $options, $logger, $dispatcher);
+        parent::__construct($tokenStorage, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, $options, $logger, $dispatcher);
     }
 
     /**

--- a/Security/Http/Firewall/OpenIdAuthenticationListener.php
+++ b/Security/Http/Firewall/OpenIdAuthenticationListener.php
@@ -3,13 +3,10 @@ namespace Fp\OpenIdBundle\Security\Http\Firewall;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
-use Fp\OpenIdBundle\Security\Http\Event\IdentityProvidedEvent;
-use Fp\OpenIdBundle\Security\Http\SecurityEvents;
 
 class OpenIdAuthenticationListener extends AbstractOpenIdAuthenticationListener
 {

--- a/Tests/Functional/app/config/routing.yml
+++ b/Tests/Functional/app/config/routing.yml
@@ -3,5 +3,5 @@ fp_openid_security:
     resource: "@FpOpenIdBundle/Resources/config/routing/security.xml"
     
 secured_content:
-    pattern:  /secured_page
+    path:  /secured_page
     defaults:  { _controller: controller.test:securedAction }

--- a/Tests/RelyingParty/RecoveredFailureRelyingPartyTest.php
+++ b/Tests/RelyingParty/RecoveredFailureRelyingPartyTest.php
@@ -2,11 +2,10 @@
 namespace Fp\OpenIdBundle\Tests\RelyingParty;
 
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 use Fp\OpenIdBundle\RelyingParty\RecoveredFailureRelyingParty;
-use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
 
 /**
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
@@ -59,7 +58,7 @@ class RecoveredFailureRelyingPartyTest extends \PHPUnit_Framework_TestCase
         $session
             ->expects($this->once())
             ->method('get')
-            ->with($this->equalTo(SecurityContextInterface::AUTHENTICATION_ERROR))
+            ->with($this->equalTo(Security::AUTHENTICATION_ERROR))
             ->will($this->returnValue(null))
         ;
 
@@ -159,7 +158,7 @@ class RecoveredFailureRelyingPartyTest extends \PHPUnit_Framework_TestCase
         $session
             ->expects($this->once())
             ->method('remove')
-            ->with($this->equalTo(SecurityContextInterface::AUTHENTICATION_ERROR))
+            ->with($this->equalTo(Security::AUTHENTICATION_ERROR))
         ;
 
         $request = $this->createRequestStub($returnGet = 1, $returnSession = $session);

--- a/Tests/Security/Http/AbstractOpenIdAuthenticationListenerTest.php
+++ b/Tests/Security/Http/AbstractOpenIdAuthenticationListenerTest.php
@@ -9,7 +9,7 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
     public function couldBeConstructedWithRequiredSetOfArguments()
     {
         $constructorArguments = array(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -30,7 +30,7 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
     public function shouldSetEmptyArrayAsRequiredAttributesOptionsInConstructor()
     {
         $constructorArguments = array(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -61,7 +61,7 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
         );
 
         $constructorArguments = array(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -90,7 +90,7 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
     public function shouldSetEmptyArrayAsOptionalAttributesOptionsInConstructor()
     {
         $constructorArguments = array(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -117,7 +117,7 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
     public function shouldAddOptionalAttributesToOptionsWithEmptyArrayAsDefaultValue()
     {
         $constructorArguments = array(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -149,7 +149,7 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
         );
 
         $constructorArguments = array(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -233,9 +233,9 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
         $listener->setRelyingParty($this->createRelyingPartyMock());
     }
 
-    protected function createSecurityContextMock()
+    protected function createTokenStorageMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     protected function createAuthenticationManagerMock()

--- a/Tests/Security/Http/OpenIdAuthenticationListenerTest.php
+++ b/Tests/Security/Http/OpenIdAuthenticationListenerTest.php
@@ -18,7 +18,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
     public function couldBeConstructedWithRequiredSetOfArguments()
     {
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsMock(),
@@ -48,7 +48,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $httpUtilsMock,
@@ -72,7 +72,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($this->createRequestMock());
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -104,7 +104,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -146,7 +146,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($requestMock);
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -188,7 +188,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($requestMock);
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -235,7 +235,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($requestMock);
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -278,7 +278,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -312,7 +312,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($requestMock);
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $this->createAuthenticationManagerMock(),
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -369,7 +369,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($requestMock);
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $authenticationManagerMock,
             $this->createSessionAuthenticationStrategyMock(),
             $this->createHttpUtilsStub($checkRequestPathReturn = true),
@@ -429,7 +429,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->createGetResponseEventStub($requestMock);
 
         $listener = new OpenIdAuthenticationListener(
-            $this->createSecurityContextMock(),
+            $this->createTokenStorageMock(),
             $authenticationManagerMock,
             $this->createSessionAuthenticationStrategyMock(),
             $httpUtilsStub,
@@ -475,7 +475,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($expectedToken))
         ;
 
-        $securityContextMock = $this->createSecurityContextMock();
+        $securityContextMock = $this->createTokenStorageMock();
         $securityContextMock
             ->expects($this->once())
             ->method('setToken')
@@ -561,9 +561,9 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
     }
 
-    protected function createSecurityContextMock()
+    protected function createTokenStorageMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     protected function createAuthenticationManagerMock()

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": ">=5.3.2",
         "lightopenid/lightopenid": "*",
-        "symfony/symfony": "~2.2"
+        "symfony/symfony": "~2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*@stable"
+        "phpunit/phpunit": "~3.7"
     },
     "autoload": {
         "psr-0": { "Fp\\OpenIdBundle": "" }
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.7-dev"
         }
     }
 }


### PR DESCRIPTION
 * Removed all usages of `SecurityContext` and `SecurityContextInterface`
 * `SecurityContextInterfaces` is replaced to `TokenStorageInterface` in `AbstractOpenIdAuthenticationListener`
 * Cleaned imports
 * `pattern` is replaced to `path` in routing configs.