### PR TITLE
fix how we specify the lightopenid version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "lightopenid/lightopenid": "*",
+        "lightopenid/lightopenid": "dev-master",
         "symfony/symfony": "~2.7|3.*"
     },
     "require-dev": {


### PR DESCRIPTION
maybe composer changed its behaviour when using `*` as version constraint? dev-master triggers allowing dev versions.