### PR TITLE
Fix deprecation for symfony 4

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fp_openid.identity_manager.class">Fp\OpenIdBundle\Document\IdentityManager</parameter>
+        <parameter key="fp_openid.identity_manager.class">Fp\OpenIdBundle\Document\IdentityManagerInterface</parameter>
         <parameter key="fp_openid.user_manager.class">Fp\OpenIdBundle\Model\UserManager</parameter>
     </parameters>
 

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fp_openid.identity_manager.class">Fp\OpenIdBundle\Entity\IdentityManager</parameter>
+        <parameter key="fp_openid.identity_manager.class">Fp\OpenIdBundle\Entity\IdentityManagerInterface</parameter>
         <parameter key="fp_openid.user_manager.class">Fp\OpenIdBundle\Model\UserManager</parameter>
     </parameters>
 


### PR DESCRIPTION
Fix for symfony 3.3 deprecation message:

``Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "fp_openid.identity_manager" service to "Fp\OpenIdBundle\Model\IdentityManagerInterface" instead.``