### PR TITLE
compatibility with symfony 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 7.1.3
 
 before_script: composer install --dev
 

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -32,7 +32,7 @@ class SecurityController implements ContainerAwareInterface
         }
 
         return $this->container->get('templating')->renderResponse(
-            'FpOpenIdBundle:Security:login.html.'.$this->container->getParameter('fp_openid.template.engine'),
+            '@FpOpenId/Security/login.html.'.$this->container->getParameter('fp_openid.template.engine'),
             array('error' => $error)
         );
     }

--- a/DependencyInjection/Security/Factory/OpenIdFactory.php
+++ b/DependencyInjection/Security/Factory/OpenIdFactory.php
@@ -3,7 +3,7 @@ namespace Fp\OpenIdBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 
@@ -92,7 +92,7 @@ class OpenIdFactory extends AbstractFactory
     {
         $providerId = 'security.authentication.provider.fp_openid.'.$id;
         $provider = $container
-            ->setDefinition($providerId, new DefinitionDecorator('security.authentication.provider.fp_openid'))
+            ->setDefinition($providerId, new ChildDefinition('security.authentication.provider.fp_openid'))
             ->replaceArgument(0, $id);
 
         // with user provider
@@ -115,7 +115,7 @@ class OpenIdFactory extends AbstractFactory
         $entryPointId = 'security.authentication.form_entry_point.'.$id;
 
         $container
-            ->setDefinition($entryPointId, new DefinitionDecorator('security.authentication.form_entry_point'))
+            ->setDefinition($entryPointId, new ChildDefinition('security.authentication.form_entry_point'))
             ->addArgument(new Reference('security.http_utils'))
             ->addArgument($config['login_path'])
             ->addArgument($config['use_forward'])

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -2,10 +2,10 @@
 namespace Fp\OpenIdBundle\Tests\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Processor;
-
+use PHPUnit\Framework\TestCase;
 use Fp\OpenIdBundle\DependencyInjection\Configuration;
 
-class ConfigurationTest extends  \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * @test

--- a/Tests/DependencyInjection/FpOpenIdExtensionTest.php
+++ b/Tests/DependencyInjection/FpOpenIdExtensionTest.php
@@ -3,10 +3,11 @@ namespace Fp\OpenIdBundle\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PHPUnit\Framework\TestCase;
 
 use Fp\OpenIdBundle\DependencyInjection\FpOpenIdExtension;
 
-class FpOpenIdExtensionTest extends \PHPUnit_Framework_TestCase
+class FpOpenIdExtensionTest extends TestCase
 {
     public static function provideSupportedDbDrivers()
     {

--- a/Tests/DependencyInjection/Security/Factory/OpenIdFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/OpenIdFactoryTest.php
@@ -5,10 +5,11 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use PHPUnit\Framework\TestCase;
 
 use Fp\OpenIdBundle\DependencyInjection\Security\Factory\OpenIdFactory;
 
-class OpenIdFactoryTest extends \PHPUnit_Framework_TestCase
+class OpenIdFactoryTest extends TestCase
 {
     /**
      * @test

--- a/Tests/Functional/app/TestController.php
+++ b/Tests/Functional/app/TestController.php
@@ -1,15 +1,17 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\Functional;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
  * @since 4/27/12
  */
-class TestController extends ContainerAware
+class TestController
 {
+    use ContainerAwareTrait;
+
     public function securedAction()
     {
         return new Response('Secured Content');

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -32,13 +32,13 @@ framework:
     templating:      { engines: ['twig'] }
     session:
         storage_id: session.storage.mock_file
-    secret:          %secret%
+    secret:          '%secret%'
     router:          { resource: "%kernel.root_dir%/config/routing.yml" }
-    default_locale:  %locale%
+    default_locale:  '%locale%'
 
 twig:
-    debug:            %kernel.debug%
-    strict_variables: %kernel.debug%
+    debug:            '%kernel.debug%'
+    strict_variables: '%kernel.debug%'
     
 services:
     fp_openid.relying_party.fake:
@@ -46,5 +46,6 @@ services:
         
     controller.test:
         class: Fp\OpenIdBundle\Tests\Functional\TestController
+        public: true
         
         

--- a/Tests/Model/IdentityTest.php
+++ b/Tests/Model/IdentityTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\Model;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\Model\Identity;
 
-class IdentityTest extends \PHPUnit_Framework_TestCase
+class IdentityTest extends TestCase
 {
     /**
      * @test

--- a/Tests/Model/UserIdentityTest.php
+++ b/Tests/Model/UserIdentityTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\Model;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\Model\UserIdentity;
 
-class UserIdentityTest extends \PHPUnit_Framework_TestCase
+class UserIdentityTest extends TestCase
 {
     /**
      * @test
@@ -51,6 +53,6 @@ class UserIdentityTest extends \PHPUnit_Framework_TestCase
      */
     protected function createUser()
     {
-        return $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        return $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
     }
 }

--- a/Tests/Model/UserManagerTest.php
+++ b/Tests/Model/UserManagerTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\Model;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\Model\UserManager;
 
-class UserManagerTest extends \PHPUnit_Framework_TestCase
+class UserManagerTest extends TestCase
 {
     /**
      * @test
@@ -130,21 +132,21 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function createIdentityManagerMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\Model\IdentityManagerInterface');
+        return $this->createMock('Fp\OpenIdBundle\Model\IdentityManagerInterface');
     }
 
     protected function createUserMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        return $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
     }
 
     protected function createIdentityMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\Model\IdentityInterface');
+        return $this->createMock('Fp\OpenIdBundle\Model\IdentityInterface');
     }
 
     protected function createUserIdentityMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\Model\UserIdentityInterface');
+        return $this->createMock('Fp\OpenIdBundle\Model\UserIdentityInterface');
     }
 }

--- a/Tests/RelyingParty/AbstractRelyingPartyTest.php
+++ b/Tests/RelyingParty/AbstractRelyingPartyTest.php
@@ -3,6 +3,7 @@ namespace Fp\OpenIdBundle\Tests\RelyingParty;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use PHPUnit\Framework\TestCase;
 
 use Fp\OpenIdBundle\RelyingParty\AbstractRelyingParty;
 use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
@@ -11,7 +12,7 @@ use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
  * @since 4/19/12
  */
-class AbstractRelyingPartyTest extends \PHPUnit_Framework_TestCase
+class AbstractRelyingPartyTest extends TestCase
 {
     /**
      * @test

--- a/Tests/RelyingParty/IdentityProviderResponseTest.php
+++ b/Tests/RelyingParty/IdentityProviderResponseTest.php
@@ -1,13 +1,15 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\RelyingParty;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
 
 /**
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
  * @since 4/12/12
  */
-class IdentityProviderResponseTest extends \PHPUnit_Framework_TestCase
+class IdentityProviderResponseTest extends TestCase
 {
     /**
      * @test

--- a/Tests/RelyingParty/RecoveredFailureRelyingPartyTest.php
+++ b/Tests/RelyingParty/RecoveredFailureRelyingPartyTest.php
@@ -4,6 +4,7 @@ namespace Fp\OpenIdBundle\Tests\RelyingParty;
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use PHPUnit\Framework\TestCase;
 
 use Fp\OpenIdBundle\RelyingParty\RecoveredFailureRelyingParty;
 
@@ -11,7 +12,7 @@ use Fp\OpenIdBundle\RelyingParty\RecoveredFailureRelyingParty;
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
  * @since 4/12/12
  */
-class RecoveredFailureRelyingPartyTest extends \PHPUnit_Framework_TestCase
+class RecoveredFailureRelyingPartyTest extends TestCase
 {
     /**
      * @test
@@ -173,7 +174,7 @@ class RecoveredFailureRelyingPartyTest extends \PHPUnit_Framework_TestCase
 
     public function createRequestMock()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false);
+        return $this->createMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false);
     }
 
     public function createRequestStub($returnGet = null, $returnSession = null)
@@ -196,7 +197,7 @@ class RecoveredFailureRelyingPartyTest extends \PHPUnit_Framework_TestCase
 
     public function createSessionMock()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        return $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
     }
 
     public function createSessionStub($returnGet = null)

--- a/Tests/RelyingParty/RelyingPartyCollectionTest.php
+++ b/Tests/RelyingParty/RelyingPartyCollectionTest.php
@@ -1,13 +1,15 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\RelyingParty;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\RelyingParty\RelyingPartyCollection;
 
 /**
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
  * @since 4/12/12
  */
-class RelyingPartyCollectionTest extends \PHPUnit_Framework_TestCase
+class RelyingPartyCollectionTest extends TestCase
 {
     /**
      * @test
@@ -240,11 +242,11 @@ class RelyingPartyCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function createRequestMock()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
+        return $this->createMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
     }
 
     public function createRelyingPartyMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface');
+        return $this->createMock('Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface');
     }
 }

--- a/Tests/Security/Core/Authentication/Provider/OpenIdAuthenticationProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OpenIdAuthenticationProviderTest.php
@@ -5,12 +5,14 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\Security\Core\Authentication\Provider\OpenIdAuthenticationProvider;
 use Fp\OpenIdBundle\Security\Core\User\UserManagerInterface;
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
 use Fp\OpenIdBundle\Security\Core\Exception\UsernameByIdentityNotFoundException;
 
-class OpenIdAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
+class OpenIdAuthenticationProviderTest extends TestCase
 {
     /**
      * @test
@@ -94,7 +96,7 @@ class OpenIdAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
     {
         $authProvider = new OpenIdAuthenticationProvider('main');
 
-        $noneOpenIdToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $noneOpenIdToken = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $this->assertFalse($authProvider->supports($noneOpenIdToken));
         $this->assertNull($authProvider->authenticate($noneOpenIdToken));
@@ -477,22 +479,22 @@ class OpenIdAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function createUserProviderMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface');
+        return $this->createMock('Symfony\Component\Security\Core\User\UserProviderInterface');
     }
 
     protected function createUserCheckerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
+        return $this->createMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
     }
 
     protected function createUserManagerMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\Tests\Security\Core\Authentication\Provider\UserManager');
+        return $this->createMock('Fp\OpenIdBundle\Tests\Security\Core\Authentication\Provider\UserManager');
     }
 
     protected function createUserMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        return $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
     }
 }
 

--- a/Tests/Security/Core/Authentication/Token/OpenIdTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OpenIdTokenTest.php
@@ -1,13 +1,15 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\Security\Core\Authentication\Token;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
 
 /**
  * @author Kotlyar Maksim <kotlyar.maksim@gmail.com>
  * @since 4/26/12
  */
-class OpenIdTokenTest extends \PHPUnit_Framework_TestCase
+class OpenIdTokenTest extends TestCase
 {
     /**
      * @test

--- a/Tests/Security/Http/AbstractOpenIdAuthenticationListenerTest.php
+++ b/Tests/Security/Http/AbstractOpenIdAuthenticationListenerTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Fp\OpenIdBundle\Tests\Security\Http\Firewall;
 
-class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractOpenIdAuthenticationListenerTest extends TestCase
 {
     /**
      * @test
@@ -235,36 +237,36 @@ class AbstractOpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCa
 
     protected function createTokenStorageMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        return $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     protected function createAuthenticationManagerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
+        return $this->createMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
     }
 
     protected function createSessionAuthenticationStrategyMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface');
+        return $this->createMock('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface');
     }
 
     protected function createHttpUtilsMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\HttpUtils');
+        return $this->createMock('Symfony\Component\Security\Http\HttpUtils');
     }
 
     protected function createRelyingPartyMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface');
+        return $this->createMock('Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface');
     }
     
     protected function createAuthenticationSuccessHandlerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface');
+        return $this->createMock('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface');
     }
     
     protected function createAuthenticationFailureHandlerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface');
+        return $this->createMock('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface');
     }
 }

--- a/Tests/Security/Http/OpenIdAuthenticationListenerTest.php
+++ b/Tests/Security/Http/OpenIdAuthenticationListenerTest.php
@@ -6,11 +6,13 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
+use PHPUnit\Framework\TestCase;
+
 use Fp\OpenIdBundle\Security\Http\Firewall\OpenIdAuthenticationListener;
 use Fp\OpenIdBundle\RelyingParty\IdentityProviderResponse;
 use Fp\OpenIdBundle\Security\Core\Authentication\Token\OpenIdToken;
 
-class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+class OpenIdAuthenticationListenerTest extends TestCase
 {
     /**
      * @test
@@ -502,7 +504,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
  
     protected function createRelyingPartyMock()
     {
-        return $this->getMock('Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface');
+        return $this->createMock('Fp\OpenIdBundle\RelyingParty\RelyingPartyInterface');
     }
 
     protected function createRelyingPartyStub($supportsReturn = null, $manageReturn = null)
@@ -525,7 +527,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function createRequestMock()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
+        return $this->createMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
     }
 
     protected function createRequestStub($hasSessionReturn = null, $hasPreviousSession = null, $duplicateReturn = null, $getSessionReturn = null)
@@ -558,27 +560,27 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function createSessionMock()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        return $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
     }
 
     protected function createTokenStorageMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        return $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     protected function createAuthenticationManagerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
+        return $this->createMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
     }
 
     protected function createSessionAuthenticationStrategyMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface');
+        return $this->createMock('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface');
     }
 
     protected function createHttpUtilsMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\HttpUtils');
+        return $this->createMock('Symfony\Component\Security\Http\HttpUtils');
     }
 
     protected function createHttpUtilsStub($checkRequestPathResult = null, $createRedirectResponseReturn = null)
@@ -604,12 +606,12 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
      */
     protected function createAuthenticationFailureHandlerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface');
+        return $this->createMock('Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface');
     }
 
     protected function createGetResponseEventMock()
     {
-        return $this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false);
+        return $this->createMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false);
     }
 
     protected function createGetResponseEventStub($request = null)
@@ -627,7 +629,7 @@ class OpenIdAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function createAuthenticationSuccessHandlerMock()
     {
-        return $this->getMock('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface');
+        return $this->createMock('Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface');
     }
 
     protected function createAuthenticationSuccessHandlerStub()

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,21 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": "^7.1.3",
         "lightopenid/lightopenid": "dev-master",
-        "symfony/symfony": "~2.7|3.*"
+        "symfony/framework-bundle": "4.*",
+        "symfony/twig-bundle": "^4.0",
+        "symfony/yaml": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "^7.0.0",
+        "symfony/dependency-injection": "^4.0",
+        "symfony/security" : "^4.0",
+        "symfony/security-bundle" : "^4.0",
+        "symfony/framework-bundle": "4.*",
+        "symfony/templating": "^4.0",
+        "symfony/browser-kit": "^4.0",
+        "symfony/css-selector": "^4.0"
     },
     "autoload": {
         "psr-0": { "Fp\\OpenIdBundle": "" }


### PR DESCRIPTION
compatibility with symfony 4.0

- The DefinitionDecorator class has been removed. Use the ChildDefinition class instead.
- Make possible to use login.html without enabling of template in framework bundle
(https://github.com/sensiolabs/SensioGeneratorBundle/issues/587)
- change ContainerAware to ContainerAwareTrait
- upgrade phpunit to ^7.0.0
- update composer depds for symfony flex
